### PR TITLE
Fixed paragraphs spacing correctly

### DIFF
--- a/components/PostComponents/PostContentBody/PostContentBody.module.css
+++ b/components/PostComponents/PostContentBody/PostContentBody.module.css
@@ -1,16 +1,10 @@
 .postDate {
-  margin-top: 0;
-  margin-bottom: 1.5rem;
+  margin: 0 0 2.5rem 0;
   font-size: 13px;
   color: var(--text-secondary);
 }
 .postDateFormat {
   font-weight: bold;
-}
-
-.postImg {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
 }
 
 .postDropdownDivider {
@@ -26,7 +20,7 @@
 
 /* -------- Markdown styling -------- */
 .linebreak {
-  white-space: pre-wrap;
+  /* white-space: pre-wrap; */
 }
 
 .reactMarkdown {
@@ -38,11 +32,12 @@
 }
 
 .reactMarkdown p {
+  white-space: pre-wrap;
   font-style: normal;
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
-  margin: 10px 0px 0px 0px;
+  margin: 0px;
 }
 
 .reactMarkdown h3 {


### PR DESCRIPTION
The way the paragraphs were being spaced for a new line was wrong, and causing weird rendering in the list's where tthe paragraph of a list would sit below it. The fix now allows everything to render correctly with using less css around default margins for spacing as well