### PR TITLE
List's not spaced correctly & formatting everything after list as last element

### DIFF
--- a/components/PostComponents/PostContentBody/PostContentBody.module.css
+++ b/components/PostComponents/PostContentBody/PostContentBody.module.css
@@ -55,6 +55,21 @@
   padding-bottom: 20px;
 }
 
+.reactMarkdown ul {
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  margin-top: -20px;
+  margin-bottom: -10px;
+}
+
+.reactMarkdown li {
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  margin-top: -15px;
+}
+
 .reactMarkdown img {
   display: block;
   max-width: 100%;


### PR DESCRIPTION
The line/top/bottom spacing of the <ul> and <li> was really messy, so cleaned that up

Also noticed everything after the last <li> tag stayed within the <li> item. It wasn't closing off the <ul> list. Had to do 3 new lines in the markdown to correct this. Then did some CSS to clean up the huge space