### PR TITLE
Fix lists spacing out weirdly

### DIFF
--- a/components/PostComponents/PostContentBody/PostContentBody.module.css
+++ b/components/PostComponents/PostContentBody/PostContentBody.module.css
@@ -59,15 +59,14 @@
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
-  margin-top: -20px;
-  margin-bottom: -10px;
+  margin-top: -10px;
+  margin-bottom: 0px;
 }
 
 .reactMarkdown li {
   font-weight: 500;
   font-size: 14px;
   line-height: 20px;
-  margin-top: -15px;
 }
 
 .reactMarkdown img {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -62,6 +62,11 @@ h3 {
   color: var(--heading-secondary);
 }
 
+/* To prevent the "linebreak" cssspacing out lists weirdly */
+ul {
+  white-space: normal;
+}
+
 .scrollTop {
   position: fixed;
   bottom: 100px;


### PR DESCRIPTION
This was being caused from the PostContentBody.module.css `.linebreak {}` class doing the `white-space: pre-wrap`. So now for `ul` we'll reset back to normal